### PR TITLE
fix: Updated default status codes

### DIFF
--- a/scim2_client/client.py
+++ b/scim2_client/client.py
@@ -74,6 +74,7 @@ class SCIMClient:
     """
 
     CREATION_RESPONSE_STATUS_CODES: list[int] = [
+        200,
         201,
         409,
         307,
@@ -136,6 +137,7 @@ class SCIMClient:
 
     REPLACEMENT_RESPONSE_STATUS_CODES: list[int] = [
         200,
+        201,
         307,
         308,
         400,

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -204,32 +204,6 @@ def test_conflict(httpserver, sync_client):
     )
 
 
-def test_no_200(httpserver, sync_client):
-    """User creation object should return 201 codes and no 200."""
-    httpserver.expect_request("/Users", method="POST").respond_with_json(
-        {
-            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
-            "id": "2819c223-7f76-453a-919d-413861904646",
-            "userName": "bjensen@example.com",
-            "meta": {
-                "resourceType": "User",
-                "created": "2010-01-23T04:56:22Z",
-                "lastModified": "2011-05-13T04:42:34Z",
-                "version": 'W\\/"3694e05e9dff590"',
-                "location": "https://example.com/v2/Users/2819c223-7f76-453a-919d-413861904646",
-            },
-        },
-        status=200,
-    )
-
-    user_request = User(user_name="bjensen@example.com")
-
-    with pytest.raises(UnexpectedStatusCode):
-        sync_client.create(user_request)
-    sync_client.create(user_request, expected_status_codes=None)
-    sync_client.create(user_request, expected_status_codes=[200, 201])
-
-
 @pytest.mark.parametrize("code", [400, 401, 403, 404, 500])
 def test_errors(httpserver, code, sync_client):
     """Test error cases defined in RFC7644."""


### PR DESCRIPTION
It is common for POST request to respond with status code 200. Not accepting it by default is definitely too strict and causes unnecessary errors.

Also added status code 201 for PUT request for the possibility that you create a new resource.

Changes:
- Added 200 for POST
- Added 201 for PUT